### PR TITLE
v2.0 - bucket policy, removed user_name input, new outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ provider "aws" {
   profile = "digital-sandbox"
 }
 
-module "s3-user" {
-  source = "github.com/turnerlabs/terraform-s3-user?ref=v1.4"
+module "s3_user" {
+  source = "github.com/turnerlabs/terraform-s3-user?ref=v2.0"
 
   bucket_name = "my-bucket"
-  user_name   = "srv_dev_my-bucket"
-  versioning  = true
 
   tag_team          = "my-team"
   tag_contact-email = "my-team@turner.com"
@@ -27,7 +25,16 @@ module "s3-user" {
 
 ### outputs
 
-- `user_arn` - user's ARN
 - `bucket_arn` - bucket's ARN
+- `bucket_name` - bucket's name
+- `user_arn` - user's ARN
+- `user_name` - user's name
 - `iam_access_key_id` - IAM access key
 - `iam_access_key_secret` - IAM access secret
+
+
+view output
+
+```
+$ terraform output -module s3_user
+```

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # we need a service account user
 resource "aws_iam_user" "user" {
-  name = "${var.user_name}"
+  name = "srv_${var.bucket_name}"
 }
 
 # generate keys for service account user
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = "true"
 
   versioning {
-    enabled = "${var.versioning}"
+    enabled = "true"
   }
 
   tags {
@@ -26,10 +26,9 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 
-# add a user policy that grants service account user access to the s3 bucket
-resource "aws_iam_user_policy" "s3" {
-  name = "${var.bucket_name}"
-  user = "${var.user_name}"
+# grant user access to the bucket
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = "${aws_s3_bucket.bucket.id}"
 
   policy = <<EOF
 {
@@ -37,9 +36,10 @@ resource "aws_iam_user_policy" "s3" {
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
+      "Principal": {
+        "AWS": "${aws_iam_user.user.arn}"
+      },
+      "Action": [ "s3:*" ],
       "Resource": [
         "${aws_s3_bucket.bucket.arn}",
         "${aws_s3_bucket.bucket.arn}/*"

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = "true"
 
   versioning {
-    enabled = "true"
+    enabled = "${var.versioning}"
   }
 
   tags {

--- a/output.tf
+++ b/output.tf
@@ -2,8 +2,16 @@ output "user_arn" {
   value = "${aws_iam_user.user.arn}"
 }
 
+output "user_name" {
+  value = "${aws_iam_user.user.name}"
+}
+
 output "bucket_arn" {
   value = "${aws_s3_bucket.bucket.arn}"
+}
+
+output "bucket_name" {
+  value = "${aws_s3_bucket.bucket.id}"
 }
 
 output "iam_access_key_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,5 @@
 variable "bucket_name" {}
 
-variable "user_name" {}
-
 variable "versioning" {
   default = false
 }


### PR DESCRIPTION
changes:

- use `bucket policy` instead of user policy
- remove `user_name` input to enforce service account naming convention
- add additional outputs (`user_name` and `bucket_name`)